### PR TITLE
Modify cond struct internal representation; implement FnResult

### DIFF
--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -4,6 +4,7 @@
          run
          exn:fail:syntax:cs450?
          lm-result?
+         FnResult?
          INIT-ENV-add!
          INIT-ENV-show
          NaN ; TODO: don't provide (but makes testing easier)
@@ -226,7 +227,7 @@
 ;; - Boolean
 ;; - NaN
 ;; - ErrorResult
-;; - RacketFn
+;; - FnResult
 ;; Interp: possible results of a CS450Lang program
 ;; Note: NaN is a valid result, but not a valid program (for now)
 (struct nan [])
@@ -255,7 +256,16 @@
 ;; What to return when a cond expression has no true entries
 (define COND-EXHAUSTED FAILED-COND-ERROR)
 
+;; A FnResult is one of:
+;; - (Racket) function
+;; - (lm-result List<Var> AST Environment)
+
 (struct lm-result [params code env] #:transparent)
+
+(define (FnResult? x)
+  ((disjoin procedure?
+            lm-result?)
+   x))
 
 (define (Result? x)
   ((disjoin number?
@@ -263,8 +273,7 @@
             boolean?
             nan?
             ErrorResult?
-            procedure?
-            lm-result?
+            FnResult?
             list?
             image?
             void?) ; need void for testing forms
@@ -468,7 +477,7 @@
   (make-parameter
    `((+ ,450+)
      (- ,450-)
-    ; (* ,*)
+     ;(* ,*)
      (* ,450*)
      (=== ,450=)
      ;(~= ,450loose=)
@@ -509,7 +518,9 @@
      [UNDEF-ERR? ,undefined-var-err?]
      [ARITY-ERR? ,arity-err?]
      [NOT-FN-ERR? ,not-fn-err?]
+     [FAILED-COND-ERR ,failed-cond-err?]
      (lm-result? ,lm-result?)
+     (FnResult? ,FnResult?)
      )))
 
 
@@ -532,20 +543,22 @@
     (match tb
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (map (curryr run/env new-env) bodys)
+       (last
+        (map (curryr run/env new-env) bodys))
        new-env]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (map (curryr run/env env/placeholder) bodys)
+       (last
+        (map (curryr run/env env/placeholder) bodys))
        env/placeholder]
       [_
        (run/env tb env)
        env]))
 
-  ;; 450apply :
+  ;; 450apply : FnResult List<Result> -> Result
   ;; Applies a function to the given arguments
   (define (450apply f args)
     (match f
@@ -578,9 +591,9 @@
        (set-box! placeholder x-result)
        (last
         (map (curryr run/env env/placeholder) bodys))]
-  ;      [(add x y) (450+ (run/env x env) (run/env y env))]
-  ;      [(sub x y) (450- (run/env x env) (run/env y env))]
-  ;      [(eq x y) (450= (run/env x env) (run/env y env))]
+      ;[(add x y) (450+ (run/env x env) (run/env y env))]
+      ;[(sub x y) (450- (run/env x env) (run/env y env))]
+      ;[(eq x y) (450= (run/env x env) (run/env y env))]
       [(ite tst thn els)
        (define tst-res (run/env tst env))
        (if (ErrorResult? tst-res)
@@ -589,8 +602,9 @@
                (run/env thn env)
                (run/env els env)))]
       [(cnd tests then-bodies)
-      ;; tries the first cond statement, if false, moves on
-      ;; until there is a true test or no more statements.
+       ;; evaluates the text-expr of the first cond-clause, if false moves on.
+       ;; until there is a true test-expr or no more clauses.
+       ;; invariant: (= (length tests) (length (then-bodies)))
        (define (try-cond tests then-bodies)
          (cond
            [(empty? tests) COND-EXHAUSTED]
@@ -626,7 +640,8 @@
       [(chktrue tst) (check-true (run/env tst env))]
       [(chkfalse tst) (check-false (run/env tst env))]
       [(chkerr p? err)
-       (check-true ((run/env p? env) (run/env err env)))]))
+       (check-true ((run/env p? env) (run/env err env)))]
+      ))
   (run/env p (INIT-ENV)))
 
 (define eval450 (compose run parse))

--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -164,7 +164,7 @@
         'parse "not a valid CS450 Lang program" s
         #:exn exn:fail:syntax:cs450)]))
 
-;; parse-cond : List<AST> List<List<AST>> -> AST
+;; parse-cond : List<Expr> List<List<Expr>> -> AST
 (define/contract (parse-cond tests then-bodies)
   (-> list? (listof list?) AST?)
   ;; parse-else : shorts 'else to 'TRUE! in a cond test
@@ -517,103 +517,19 @@
 ;; Computes the result of running the given CS450Lang program AST
 (define/contract (run p)
   (-> AST? Result?)
-  (run/env p (INIT-ENV)))
 
-;; 450apply
-;; Applies a function to the given arguments
-(define (450apply f args)
-  (match f
-    [(? procedure?) (apply f args)]
-    [(lm-result params body fnenv)
-     (if (= (length params) (length args))
-         (run/env body (append (map list params args) fnenv))
-         (arity-err f args))]
-    [(? undefined-var-err?) f]
-    [_ (not-fn-err f)]))
+  ;; run-then-bodies : List<List<AST>> -> Result
+  ;; Invariant: (length tbs) > 0
+  ;; Runes the then-bodies of a cond-clause with persistent environment
+  (define (run-then-bodies tbs env)
+    (cond
+      [(= 1 (length tbs)) (run/env (first tbs) env)]
+      [else (run-then-bodies (rest tbs) (run-then-body->env (first tbs) env))]))
 
-;; run/env : 450LangAST -> 450LangResult
-;; accumulator : env : Env
-;; invariant : represents variable bindings seen so far
-(define (run/env p env)
-  (match p
-    [(num n) n]
-    [(str s) s]
-    [(boo b) b]
-    [(vari x) (lookup x env)]
-    #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
-    [(bind x e bodys)
-     (define new-env (env-add x (run/env e env) env))
-     (last
-      (map (curryr run/env new-env) bodys))]
-    [(recb x e bodys)
-     (define placeholder (box (circular-err x)))
-     (define env/placeholder (env-add x placeholder env))
-     (define x-result (run/env e env/placeholder))
-     (set-box! placeholder x-result)
-     (last
-      (map (curryr run/env env/placeholder) bodys))]
-;      [(add x y) (450+ (run/env x env) (run/env y env))]
-;      [(sub x y) (450- (run/env x env) (run/env y env))]
-;      [(eq x y) (450= (run/env x env) (run/env y env))]
-    [(ite tst thn els)
-     (define tst-res (run/env tst env))
-     (if (ErrorResult? tst-res)
-         tst-res
-         (if (res->bool (run/env tst env))
-             (run/env thn env)
-             (run/env els env)))]
-    [(cnd tests then-bodies)
-    ;; tries the first cond statement, if false, moves on
-    ;; until there is a true test or no more statements.
-     (define (try-cond tests then-bodies)
-       (cond
-         [(empty? tests) COND-EXHAUSTED]
-         [(res->bool (run/env (first tests) env))
-          (run-then-bodies (first then-bodies) env)]
-         [else (try-cond (rest tests) (rest then-bodies))]))
-     (try-cond tests then-bodies)]
-    [(land args)
-     (cond [(empty? args) #t]
-           [(= (length args) 1) (run/env (first args) env)]
-           [else
-            (let ([res (run/env (first args) env)])
-              (if (res->bool res)
-                  (run/env (land (rest args)) env)
-                  res))])]
-    [(lor args)
-     (cond [(empty? args) #f]
-           [(= (length args) 1) (run/env (first args) env)]
-           [else
-            (let ([res (run/env (first args) env)])
-              (if (res->bool res)
-                  res
-                  (run/env (lor (rest args)) env)))])]
-    [(lm-ast args body) (lm-result args body env)] ; dont eval body
-    [(call fn args)
-     (define fn-res (run/env fn env))
-     (if (ErrorResult? fn-res)
-         fn-res
-         (450apply
-          fn-res
-          (map (curryr run/env env) args)))]
-    [(chk=? expected actual)
-     (check-equal? (run/env expected env) (run/env actual env))]
-    [(chktrue tst) (check-true (run/env tst env))]
-    [(chkfalse tst) (check-false (run/env tst env))]
-    [(chkerr p? err)
-     (check-true ((run/env p? env) (run/env err env)))]))
-
-;; List<List<AST>> -> Result
-;; Invariant: (length tbs) > 0
-(define (run-then-bodies tbs env)
-  (cond
-    [(= 1 (length tbs)) (run/env (first tbs) env)]
-    [else (run-then-bodies (rest tbs) (run-then-body->env (first tbs) env))]))
-
-;; run-then-body->env
-;; runs the given then-body of a cond clause and returns the (possibly altered) environment
-(define (run-then-body->env tb env)
-  (match tb
+  ;; run-then-body->env : AST -> Environment
+  ;; runs the given then-body of a cond clause and returns the (possibly altered) environment
+  (define (run-then-body->env tb env)
+    (match tb
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
        (map (curryr run/env new-env) bodys)
@@ -629,6 +545,89 @@
        (run/env tb env)
        env]))
 
+  ;; 450apply :
+  ;; Applies a function to the given arguments
+  (define (450apply f args)
+    (match f
+      [(? procedure?) (apply f args)]
+      [(lm-result params body fnenv)
+       (if (= (length params) (length args))
+           (run/env body (append (map list params args) fnenv))
+           (arity-err f args))]
+      [(? undefined-var-err?) f]
+      [_ (not-fn-err f)]))
+
+  ;; run/env : 450LangAST -> 450LangResult
+  ;; accumulator : env : Env
+  ;; invariant : represents variable bindings seen so far
+  (define (run/env p env)
+    (match p
+      [(num n) n]
+      [(str s) s]
+      [(boo b) b]
+      [(vari x) (lookup x env)]
+      #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
+      [(bind x e bodys)
+       (define new-env (env-add x (run/env e env) env))
+       (last
+        (map (curryr run/env new-env) bodys))]
+      [(recb x e bodys)
+       (define placeholder (box (circular-err x)))
+       (define env/placeholder (env-add x placeholder env))
+       (define x-result (run/env e env/placeholder))
+       (set-box! placeholder x-result)
+       (last
+        (map (curryr run/env env/placeholder) bodys))]
+  ;      [(add x y) (450+ (run/env x env) (run/env y env))]
+  ;      [(sub x y) (450- (run/env x env) (run/env y env))]
+  ;      [(eq x y) (450= (run/env x env) (run/env y env))]
+      [(ite tst thn els)
+       (define tst-res (run/env tst env))
+       (if (ErrorResult? tst-res)
+           tst-res
+           (if (res->bool (run/env tst env))
+               (run/env thn env)
+               (run/env els env)))]
+      [(cnd tests then-bodies)
+      ;; tries the first cond statement, if false, moves on
+      ;; until there is a true test or no more statements.
+       (define (try-cond tests then-bodies)
+         (cond
+           [(empty? tests) COND-EXHAUSTED]
+           [(res->bool (run/env (first tests) env))
+            (run-then-bodies (first then-bodies) env)]
+           [else (try-cond (rest tests) (rest then-bodies))]))
+       (try-cond tests then-bodies)]
+      [(land args)
+       (cond [(empty? args) #t]
+             [(= (length args) 1) (run/env (first args) env)]
+             [else
+              (let ([res (run/env (first args) env)])
+                (if (res->bool res) (run/env (land (rest args)) env)
+                    res))])]
+      [(lor args)
+       (cond [(empty? args) #f]
+             [(= (length args) 1) (run/env (first args) env)]
+             [else
+              (let ([res (run/env (first args) env)])
+                (if (res->bool res)
+                    res
+                    (run/env (lor (rest args)) env)))])]
+      [(lm-ast args body) (lm-result args body env)] ; dont eval body
+      [(call fn args)
+       (define fn-res (run/env fn env))
+       (if (ErrorResult? fn-res)
+           fn-res
+           (450apply
+            fn-res
+            (map (curryr run/env env) args)))]
+      [(chk=? expected actual)
+       (check-equal? (run/env expected env) (run/env actual env))]
+      [(chktrue tst) (check-true (run/env tst env))]
+      [(chkfalse tst) (check-false (run/env tst env))]
+      [(chkerr p? err)
+       (check-true ((run/env p? env) (run/env err env)))]))
+  (run/env p (INIT-ENV)))
 
 (define eval450 (compose run parse))
 
@@ -679,7 +678,8 @@
               "no error")
 (check-equal? (eval450 '(cond [FALSE! ((lm [x] (x x)) (lm [x] (x x)))] [else "ran one branch"]))
               "ran one branch")
-(eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] (f 1 2)) (f 2 3)]))
+(check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))]) (f 2 3)]))
+              5)
 
 ;; check shadowing, proper variable capture
 

--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -29,7 +29,7 @@
 ;; - `(bind [,Var ,Expr] ,Expr)
 ;; - `(bind/rec [,Var ,Expr] ,Expr)
 ;; - `(iffy ,Expr ,Expr ,Expr)
-;; - `(cond ,TestPair ...)
+;; - `(cond [,Expr ,Expr ...] ...)
 ;; - `(lm ,List<Var> ,Expr)
 ;; - `(∨ Expr ...)
 ;; - `(∧ Expr ...)
@@ -80,7 +80,7 @@
 ;; - (str String)
 ;; - (boo Boolean)
 ;; - (ite AST AST AST)
-;; - (cnd List<Pair<AST>)
+;; - (cnd List<AST> List<List<AST>>)
 ;; - (vari Symbol)
 ;; - (bind Symbol AST List<AST>)
 ;; - (recb Symbol AST List<AST>)
@@ -91,7 +91,7 @@
 (struct str AST [val] #:transparent)
 (struct boo AST [val] #:transparent)
 (struct ite AST [test then else] #:transparent)
-(struct cnd AST [testpairs] #:transparent)
+(struct cnd AST [tests then-bodies] #:transparent)
 (struct vari AST [name] #:transparent)
 (struct bind AST [name expr body] #:transparent)
 (struct recb AST [name expr body] #:transparent)
@@ -138,8 +138,8 @@
      (raise-syntax-error
       'parse "invalid iffy syntax, expected: (iffy test then else)" s
       #:exn exn:fail:syntax:cs450)]
-    [`(cond ,(? TestPair? testpairs) ...)
-     (parse/cond testpairs)]
+    [`(cond [,tests ,then-bodies ...] ...)
+     (parse-cond tests then-bodies)]
     [`(cond . ,_)
      (raise-syntax-error
       'parse "invalid cond syntax, expected: (cond [if-this then-that] ...)" s
@@ -164,26 +164,16 @@
         'parse "not a valid CS450 Lang program" s
         #:exn exn:fail:syntax:cs450)]))
 
-
-;; A TestPair is a `(,Expr ,Expr)
-;; used for cond statements
-(define (TestPair? x)
-  (and (list? x)
-       (= 2 (length x))))
-
-;; parse/cond : TestPairs -> AST
-(define/contract (parse/cond testpairs)
-  (-> (listof TestPair?) AST?)
-  ;; parse/else : shorts 'else to 'TRUE! in a cond test
-  (define (parse/else s)
+;; parse-cond : List<AST> List<List<AST>> -> AST
+(define/contract (parse-cond tests then-bodies)
+  (-> list? (listof list?) AST?)
+  ;; parse-else : shorts 'else to 'TRUE! in a cond test
+  (define (parse-else s)
     (if (equal? 'else s)
         (parse 'TRUE!)
         (parse s)))
-  (cnd
-   (map list
-        (map (compose parse/else first) testpairs)
-        (map (compose parse second) testpairs))))
-   
+  (cnd (map parse-else tests)
+       (map (curry map parse) then-bodies)))
 
 (check-equal? (parse 1) (num 1))
 (check-equal? (parse '(+ 1 2))
@@ -208,13 +198,18 @@
                    (num 100)
                    (num 200)))
 (check-equal? (parse '(cond [(> 3 5) "three"] [(< 3 5) "five"] [else "none"]))
-              (cnd
-               (list (list (call (vari '>) (list (num 3) (num 5)))
-                           (str "three"))
-                     (list (call (vari '<) (list (num 3) (num 5)))
-                           (str "five"))
-                     (list (boo #t)
-                           (str "none")))))
+              (cnd (list (call (vari '>) (list (num 3) (num 5)))
+                         (call (vari '<) (list (num 3) (num 5)))
+                         (boo #t))
+                   (list (list (str "three"))
+                         (list (str "five"))
+                         (list (str "none")))))
+(check-equal? (parse '(cond [(> 0 2) (+ 1 1)] [else (+ 2 2) (+ 3 3)]))
+              (cnd (list (call (vari '>) (list (num 0) (num 2)))
+                         (boo #t))
+                   (list (list (call (vari '+) (list (num 1) (num 1))))
+                         (list (call (vari '+) (list (num 2) (num 2)))
+                               (call (vari '+) (list (num 3) (num 3)))))))
 
 (check-equal? (parse '(bind [x 1] x))
               (bind 'x (num 1) (list (vari 'x))))
@@ -522,89 +517,118 @@
 ;; Computes the result of running the given CS450Lang program AST
 (define/contract (run p)
   (-> AST? Result?)
+  (run/env p (INIT-ENV)))
 
-  (define (450apply f args)
-    (match f
-      [(? procedure?) (apply f args)]
-      [(lm-result params body fnenv)
-       (if (= (length params) (length args))
-           (run/env body (append (map list params args) fnenv))
-           (arity-err f args))]
-      [(? undefined-var-err?) f]
-      [_ (not-fn-err f)]))
+;; 450apply
+;; Applies a function to the given arguments
+(define (450apply f args)
+  (match f
+    [(? procedure?) (apply f args)]
+    [(lm-result params body fnenv)
+     (if (= (length params) (length args))
+         (run/env body (append (map list params args) fnenv))
+         (arity-err f args))]
+    [(? undefined-var-err?) f]
+    [_ (not-fn-err f)]))
 
-     ;; accumulator : env : Env
-  ;; invariant : represents variable bindings seen so far
-  (define (run/env p env)
-    (match p
-      [(num n) n]
-      [(str s) s]
-      [(boo b) b]
-      [(vari x) (lookup x env)]
-      #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
+;; run/env : 450LangAST -> 450LangResult
+;; accumulator : env : Env
+;; invariant : represents variable bindings seen so far
+(define (run/env p env)
+  (match p
+    [(num n) n]
+    [(str s) s]
+    [(boo b) b]
+    [(vari x) (lookup x env)]
+    #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
+    [(bind x e bodys)
+     (define new-env (env-add x (run/env e env) env))
+     (last
+      (map (curryr run/env new-env) bodys))]
+    [(recb x e bodys)
+     (define placeholder (box (circular-err x)))
+     (define env/placeholder (env-add x placeholder env))
+     (define x-result (run/env e env/placeholder))
+     (set-box! placeholder x-result)
+     (last
+      (map (curryr run/env env/placeholder) bodys))]
+;      [(add x y) (450+ (run/env x env) (run/env y env))]
+;      [(sub x y) (450- (run/env x env) (run/env y env))]
+;      [(eq x y) (450= (run/env x env) (run/env y env))]
+    [(ite tst thn els)
+     (define tst-res (run/env tst env))
+     (if (ErrorResult? tst-res)
+         tst-res
+         (if (res->bool (run/env tst env))
+             (run/env thn env)
+             (run/env els env)))]
+    [(cnd tests then-bodies)
+    ;; tries the first cond statement, if false, moves on
+    ;; until there is a true test or no more statements.
+     (define (try-cond tests then-bodies)
+       (cond
+         [(empty? tests) COND-EXHAUSTED]
+         [(res->bool (run/env (first tests) env))
+          (run-then-bodies (first then-bodies) env)]
+         [else (try-cond (rest tests) (rest then-bodies))]))
+     (try-cond tests then-bodies)]
+    [(land args)
+     (cond [(empty? args) #t]
+           [(= (length args) 1) (run/env (first args) env)]
+           [else
+            (let ([res (run/env (first args) env)])
+              (if (res->bool res)
+                  (run/env (land (rest args)) env)
+                  res))])]
+    [(lor args)
+     (cond [(empty? args) #f]
+           [(= (length args) 1) (run/env (first args) env)]
+           [else
+            (let ([res (run/env (first args) env)])
+              (if (res->bool res)
+                  res
+                  (run/env (lor (rest args)) env)))])]
+    [(lm-ast args body) (lm-result args body env)] ; dont eval body
+    [(call fn args)
+     (define fn-res (run/env fn env))
+     (if (ErrorResult? fn-res)
+         fn-res
+         (450apply
+          fn-res
+          (map (curryr run/env env) args)))]
+    [(chk=? expected actual)
+     (check-equal? (run/env expected env) (run/env actual env))]
+    [(chktrue tst) (check-true (run/env tst env))]
+    [(chkfalse tst) (check-false (run/env tst env))]
+    [(chkerr p? err)
+     (check-true ((run/env p? env) (run/env err env)))]))
+
+;; List<List<AST>> -> Result
+;; Invariant: (length tbs) > 0
+(define (run-then-bodies tbs env)
+  (cond
+    [(= 1 (length tbs)) (run/env (first tbs) env)]
+    [else (run-then-bodies (rest tbs) (run-then-body->env (first tbs) env))]))
+
+;; run-then-body->env
+;; runs the given then-body of a cond clause and returns the (possibly altered) environment
+(define (run-then-body->env tb env)
+  (match tb
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (last
-        (map (curryr run/env new-env) bodys))]
+       (map (curryr run/env new-env) bodys)
+       new-env]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (last
-        (map (curryr run/env env/placeholder) bodys))]
-;      [(add x y) (450+ (run/env x env) (run/env y env))]
-;      [(sub x y) (450- (run/env x env) (run/env y env))]
-;      [(eq x y) (450= (run/env x env) (run/env y env))]
-      [(ite tst thn els)
-       (define tst-res (run/env tst env))
-       (if (ErrorResult? tst-res)
-           tst-res
-           (if (res->bool (run/env tst env))
-               (run/env thn env)
-               (run/env els env)))]
-      [(cnd testpairs)
-       ;; tries the first cond statement, if false, moves on
-       ;; until there is a true test or no more statements.
-       (define (try-cond tps)
-         (cond
-           [(empty? tps) COND-EXHAUSTED]
-           [(res->bool (run/env (first (first tps)) env)) (run/env (second (first tps)) env)]
-           [else (try-cond (rest tps))]))
-       (try-cond testpairs)]
-      [(land args)
-       (cond [(empty? args) #t]
-             [(= (length args) 1) (run/env (first args) env)]
-             [else
-              (let ([res (run/env (first args) env)])
-                (if (res->bool res)
-                    (run/env (land (rest args)) env)
-                    res))])]           
-      [(lor args)
-       (cond [(empty? args) #f]
-             [(= (length args) 1) (run/env (first args) env)]
-             [else
-              (let ([res (run/env (first args) env)])
-                (if (res->bool res)
-                    res
-                    (run/env (lor (rest args)) env)))])]           
-      [(lm-ast args body) (lm-result args body env)] ; dont eval body
-      [(call fn args)
-       (define fn-res (run/env fn env))
-       (if (ErrorResult? fn-res)
-           fn-res
-           (450apply
-            fn-res
-            (map (curryr run/env env) args)))]
-      [(chk=? expected actual)
-       (check-equal? (run/env expected env) (run/env actual env))]
-      [(chktrue tst) (check-true (run/env tst env))]
-      [(chkfalse tst) (check-false (run/env tst env))]
-      [(chkerr p? err)
-       (check-true ((run/env p? env) (run/env err env)))]
-  ))
+       (map (curryr run/env env/placeholder) bodys)
+       env/placeholder]
+      [_
+       (run/env tb env)
+       env]))
 
-  (run/env p (INIT-ENV)))
 
 (define eval450 (compose run parse))
 
@@ -655,6 +679,7 @@
               "no error")
 (check-equal? (eval450 '(cond [FALSE! ((lm [x] (x x)) (lm [x] (x x)))] [else "ran one branch"]))
               "ran one branch")
+(eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] (f 1 2)) (f 2 3)]))
 
 ;; check shadowing, proper variable capture
 

--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -27,10 +27,10 @@
 ;; A 450LangExpr (Expr) is one of
 ;; - Atom
 ;; - Variable
-;; - `(bind [,Var ,Expr] ,Expr)
-;; - `(bind/rec [,Var ,Expr] ,Expr)
+;; - `(bind [,Var ,Expr] ,Expr ...+)
+;; - `(bind/rec [,Var ,Expr] ,Expr ...+)
 ;; - `(iffy ,Expr ,Expr ,Expr)
-;; - `(cond [,Expr ,Expr ...] ...)
+;; - `(cond [,Expr ,Expr ...+] ...+)
 ;; - `(lm ,List<Var> ,Expr)
 ;; - `(∨ Expr ...)
 ;; - `(∧ Expr ...)
@@ -119,12 +119,12 @@
     ['TRUE! (boo true)]
     ['FALSE! (boo false)]
     [(? symbol?) (vari s)]
-    [`(bind [,x ,e] . ,bods) (bind x (parse e) (map parse bods))]
+    [`(bind [,x ,e] ,bods ..1) (bind x (parse e) (map parse bods))]
     [`(bind . ,_)
      (raise-syntax-error
       'parse "bind: invalid syntax, expected: (bind [x e] body)" s
       #:exn exn:fail:syntax:cs450)]
-    [`(bind/rec [,x ,e] . ,bods) (recb x (parse e) (map parse bods))]
+    [`(bind/rec [,x ,e] ,bods ..1) (recb x (parse e) (map parse bods))]
     [`(bind/rec . ,_)
      (raise-syntax-error
       'parse "bind/rec: invalid syntax, expected: (bind/rec [x e] body)" s
@@ -139,7 +139,7 @@
      (raise-syntax-error
       'parse "invalid iffy syntax, expected: (iffy test then else)" s
       #:exn exn:fail:syntax:cs450)]
-    [`(cond [,tests ,then-bodies ...] ...)
+    [`(cond [,tests ,then-bodies ..1] ..1)
      (parse-cond tests then-bodies)]
     [`(cond . ,_)
      (raise-syntax-error
@@ -543,18 +543,16 @@
     (match tb
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       ;(last
-       (map (curryr run/env new-env) bodys)
-       ;)
+       (last
+        (map (curryr run/env new-env) bodys))
        new-env]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       ;(last
-       (map (curryr run/env env/placeholder) bodys)
-       ;)
+       (last
+        (map (curryr run/env env/placeholder) bodys))
        env/placeholder]
       [_
        (run/env tb env)
@@ -584,19 +582,15 @@
       #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       ;(last
-       (map (curryr run/env new-env) bodys)
-       ;)
-      ]
+       (last
+        (map (curryr run/env new-env) bodys))]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       ;(last
-       (map (curryr run/env env/placeholder) bodys)
-        ;)
-      ]
+       (last
+        (map (curryr run/env env/placeholder) bodys))]
       ;[(add x y) (450+ (run/env x env) (run/env y env))]
       ;[(sub x y) (450- (run/env x env) (run/env y env))]
       ;[(eq x y) (450= (run/env x env) (run/env y env))]
@@ -699,7 +693,7 @@
               "no error")
 (check-equal? (eval450 '(cond [FALSE! ((lm [x] (x x)) (lm [x] (x x)))] [else "ran one branch"]))
               "ran one branch")
-(check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))]) (f 2 3)]))
+(check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] f) (f 2 3)]))
               5)
 
 ;; check shadowing, proper variable capture

--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -543,16 +543,18 @@
     (match tb
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (last
-        (map (curryr run/env new-env) bodys))
+       ;(last
+       (map (curryr run/env new-env) bodys)
+       ;)
        new-env]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (last
-        (map (curryr run/env env/placeholder) bodys))
+       ;(last
+       (map (curryr run/env env/placeholder) bodys)
+       ;)
        env/placeholder]
       [_
        (run/env tb env)
@@ -582,15 +584,19 @@
       #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (last
-        (map (curryr run/env new-env) bodys))]
+       ;(last
+       (map (curryr run/env new-env) bodys)
+       ;)
+      ]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (last
-        (map (curryr run/env env/placeholder) bodys))]
+       ;(last
+       (map (curryr run/env env/placeholder) bodys)
+        ;)
+      ]
       ;[(add x y) (450+ (run/env x env) (run/env y env))]
       ;[(sub x y) (450- (run/env x env) (run/env y env))]
       ;[(eq x y) (450= (run/env x env) (run/env y env))]

--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -529,34 +529,54 @@
 (define/contract (run p)
   (-> AST? Result?)
 
+  ;; last-res-or-first-err
+  ;; Returns the last result of the given bodies, or the first computed error
+  (define (last-res-or-first-err bodys env)
+    (cond
+      [(= 1 (length bodys)) (run/env (first bodys) env)]
+      [else
+       (define maybe-err (run/env (first bodys) env))
+       (if (ErrorResult? maybe-err)
+           maybe-err
+           (last-res-or-first-err (rest bodys) env))]))
+
   ;; run-then-bodies : List<List<AST>> -> Result
   ;; Invariant: (length tbs) > 0
-  ;; Runes the then-bodies of a cond-clause with persistent environment
+  ;; Runs the then-bodies of a cond-clause with persistent environment
   (define (run-then-bodies tbs env)
     (cond
-      [(= 1 (length tbs)) (run/env (first tbs) env)]
-      [else (run-then-bodies (rest tbs) (run-then-body->env (first tbs) env))]))
+      [(= 1 (length tbs))
+       (run/env (first tbs) env)]
+      [else
+       (define env-or-err (run-then-body->env-or-err (first tbs) env))
+       (if (ErrorResult? env-or-err)
+           env-or-err
+           (run-then-bodies (rest tbs) env-or-err))]))
 
   ;; run-then-body->env : AST -> Environment
   ;; runs the given then-body of a cond clause and returns the (possibly altered) environment
-  (define (run-then-body->env tb env)
+  (define (run-then-body->env-or-err tb env)
     (match tb
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (last
-        (map (curryr run/env new-env) bodys))
-       new-env]
+       (define maybe-err (last-res-or-first-err bodys new-env))
+       (if (ErrorResult? maybe-err)
+           maybe-err
+           new-env)]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (last
-        (map (curryr run/env env/placeholder) bodys))
-       env/placeholder]
+       (define maybe-err (last-res-or-first-err bodys env/placeholder))
+       (if (ErrorResult? maybe-err)
+           maybe-err
+           env/placeholder)]
       [_
-       (run/env tb env)
-       env]))
+       (define maybe-err (run/env tb env))
+       (if (ErrorResult? maybe-err)
+           maybe-err
+           env)]))
 
   ;; 450apply : FnResult List<Result> -> Result
   ;; Applies a function to the given arguments
@@ -582,15 +602,13 @@
       #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (last
-        (map (curryr run/env new-env) bodys))]
+       (last-res-or-first-err bodys new-env)]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (last
-        (map (curryr run/env env/placeholder) bodys))]
+       (last-res-or-first-err bodys env/placeholder)]
       ;[(add x y) (450+ (run/env x env) (run/env y env))]
       ;[(sub x y) (450- (run/env x env) (run/env y env))]
       ;[(eq x y) (450= (run/env x env) (run/env y env))]
@@ -602,7 +620,7 @@
                (run/env thn env)
                (run/env els env)))]
       [(cnd tests then-bodies)
-       ;; evaluates the text-expr of the first cond-clause, if false moves on.
+       ;; evaluates the text-expr of the first cond-clause, if false moves on
        ;; until there is a true test-expr or no more clauses.
        ;; invariant: (= (length tests) (length (then-bodies)))
        (define (try-cond tests then-bodies)
@@ -617,7 +635,8 @@
              [(= (length args) 1) (run/env (first args) env)]
              [else
               (let ([res (run/env (first args) env)])
-                (if (res->bool res) (run/env (land (rest args)) env)
+                (if (res->bool res)
+                    (run/env (land (rest args)) env)
                     res))])]
       [(lor args)
        (cond [(empty? args) #f]
@@ -695,6 +714,9 @@
               "ran one branch")
 (check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] f) (f 2 3)]))
               5)
+(check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] f) (bind/rec [g 3] g) (f 2 g)]))
+              5)
+(check-true (undefined-var-err? (eval450 '(cond [else (bind/rec [x 5] x) (+ x y) (+ x 1)]))))
 
 ;; check shadowing, proper variable capture
 

--- a/450lang-lib/450lang/cs450-lang-impl.rkt
+++ b/450lang-lib/450lang/cs450-lang-impl.rkt
@@ -27,10 +27,10 @@
 ;; A 450LangExpr (Expr) is one of
 ;; - Atom
 ;; - Variable
-;; - `(bind [,Var ,Expr] ,Expr ...+)
-;; - `(bind/rec [,Var ,Expr] ,Expr ...+)
+;; - `(bind [,Var ,Expr] ,Expr)
+;; - `(bind/rec [,Var ,Expr] ,Expr)
 ;; - `(iffy ,Expr ,Expr ,Expr)
-;; - `(cond [,Expr ,Expr ...+] ...+)
+;; - `(cond [,Expr ,Expr] ...)
 ;; - `(lm ,List<Var> ,Expr)
 ;; - `(∨ Expr ...)
 ;; - `(∧ Expr ...)
@@ -81,7 +81,7 @@
 ;; - (str String)
 ;; - (boo Boolean)
 ;; - (ite AST AST AST)
-;; - (cnd List<AST> List<List<AST>>)
+;; - (cnd List<AST> List<AST>)
 ;; - (vari Symbol)
 ;; - (bind Symbol AST List<AST>)
 ;; - (recb Symbol AST List<AST>)
@@ -529,55 +529,6 @@
 (define/contract (run p)
   (-> AST? Result?)
 
-  ;; last-res-or-first-err
-  ;; Returns the last result of the given bodies, or the first computed error
-  (define (last-res-or-first-err bodys env)
-    (cond
-      [(= 1 (length bodys)) (run/env (first bodys) env)]
-      [else
-       (define maybe-err (run/env (first bodys) env))
-       (if (ErrorResult? maybe-err)
-           maybe-err
-           (last-res-or-first-err (rest bodys) env))]))
-
-  ;; run-then-bodies : List<List<AST>> -> Result
-  ;; Invariant: (length tbs) > 0
-  ;; Runs the then-bodies of a cond-clause with persistent environment
-  (define (run-then-bodies tbs env)
-    (cond
-      [(= 1 (length tbs))
-       (run/env (first tbs) env)]
-      [else
-       (define env-or-err (run-then-body->env-or-err (first tbs) env))
-       (if (ErrorResult? env-or-err)
-           env-or-err
-           (run-then-bodies (rest tbs) env-or-err))]))
-
-  ;; run-then-body->env : AST -> Environment
-  ;; runs the given then-body of a cond clause and returns the (possibly altered) environment
-  (define (run-then-body->env-or-err tb env)
-    (match tb
-      [(bind x e bodys)
-       (define new-env (env-add x (run/env e env) env))
-       (define maybe-err (last-res-or-first-err bodys new-env))
-       (if (ErrorResult? maybe-err)
-           maybe-err
-           new-env)]
-      [(recb x e bodys)
-       (define placeholder (box (circular-err x)))
-       (define env/placeholder (env-add x placeholder env))
-       (define x-result (run/env e env/placeholder))
-       (set-box! placeholder x-result)
-       (define maybe-err (last-res-or-first-err bodys env/placeholder))
-       (if (ErrorResult? maybe-err)
-           maybe-err
-           env/placeholder)]
-      [_
-       (define maybe-err (run/env tb env))
-       (if (ErrorResult? maybe-err)
-           maybe-err
-           env)]))
-
   ;; 450apply : FnResult List<Result> -> Result
   ;; Applies a function to the given arguments
   (define (450apply f args)
@@ -602,13 +553,15 @@
       #;[(bind x e body) (run/env body (env-add x (run/env e env) env))]
       [(bind x e bodys)
        (define new-env (env-add x (run/env e env) env))
-       (last-res-or-first-err bodys new-env)]
+       (last
+        (map (curryr run/env new-env) bodys))]
       [(recb x e bodys)
        (define placeholder (box (circular-err x)))
        (define env/placeholder (env-add x placeholder env))
        (define x-result (run/env e env/placeholder))
        (set-box! placeholder x-result)
-       (last-res-or-first-err bodys env/placeholder)]
+       (last
+        (map (curryr run/env env/placeholder) bodys))]
       ;[(add x y) (450+ (run/env x env) (run/env y env))]
       ;[(sub x y) (450- (run/env x env) (run/env y env))]
       ;[(eq x y) (450= (run/env x env) (run/env y env))]
@@ -627,7 +580,8 @@
          (cond
            [(empty? tests) COND-EXHAUSTED]
            [(res->bool (run/env (first tests) env))
-            (run-then-bodies (first then-bodies) env)]
+            (last
+             (map (curryr run/env env) (first then-bodies)))]
            [else (try-cond (rest tests) (rest then-bodies))]))
        (try-cond tests then-bodies)]
       [(land args)
@@ -712,11 +666,8 @@
               "no error")
 (check-equal? (eval450 '(cond [FALSE! ((lm [x] (x x)) (lm [x] (x x)))] [else "ran one branch"]))
               "ran one branch")
-(check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] f) (f 2 3)]))
-              5)
-(check-equal? (eval450 '(cond [else (bind/rec [f (lm (x y) (+ x y))] f) (bind/rec [g 3] g) (f 2 g)]))
-              5)
-(check-true (undefined-var-err? (eval450 '(cond [else (bind/rec [x 5] x) (+ x y) (+ x 1)]))))
+(check-equal? (eval450 '(cond [else (+ 1 1) (+ 2 2)]))
+              4)
 
 ;; check shadowing, proper variable capture
 


### PR DESCRIPTION
I've modified the `cond` case of the `Expr` and `AST` data definitions to be easier to work with (two corresponding lists of `test-expr`s and `test-body`s as opposed to one list of pairs). Internally, this is implemented to allow for multiple `test-body`s in the same way that `bind` and `bind/rec` allow, however the data definition does not reflect this as there isn't much of a point without `define`. 

I've also modified the `bind`, `bind/rec`, and `cond` pattern match in `parse` to follow this - explicitly require at least one body. The `run` implementation returns the last of the results of the `test-body`s, and does not error check intermediate results (following what you said regarding `bind` and `bind/rec`. 

This cleans up the code in both `parse` and `run`, so I think it's worth it just for that reason, but it will also make implementing `define` more approachable. Let me know if there are any issues you see - all tests still pass, at the very least. The commit history is a bit verbose and goes back and forth (bad habit) so do whatever you want to make it more reasonable. 